### PR TITLE
Updated the navigational link to Piazza with a working link

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -7,7 +7,7 @@
   absolute: False
 
 - title: Piazza
-  url:  https://piazza.com/mail.utoronto.ca/fall2020/cscd27
+  url:  https://piazza.com/utoronto.ca/fall2020/cscd27
   absolute: True
 
 - title: Github


### PR DESCRIPTION
The current navigational link to Piazza goes directly to a 404 Not Found page. The updated link in the pull request links to the class Piazza page. Other course sites for the courses you teach may need to be updated as well. Cheers!

![screencapture-piazza-mail-utoronto-ca-fall2020-cscd27-2020-09-22-17_52_35](https://user-images.githubusercontent.com/5105156/93941477-8c0f6a00-fcfc-11ea-8019-f1da882d8448.png)
